### PR TITLE
fix: return a null token if the token is invalid or fails verification

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -19,9 +19,16 @@ export const plugin: RuntimePlugin<Settings, 'required'> = settings => project =
           }
         } else if (req.headers.authorization && req.headers.authorization.split(' ')[0] === 'Bearer') {
           const token = req.headers.authorization.split(' ')[1]
-          const verifiedToken = verify(token, settings.appSecret)
-          return {
-            token: verifiedToken
+          try {
+            const verifiedToken = verify(token, settings.appSecret)
+            return {
+              token: verifiedToken
+            }
+          }
+          catch (err) {
+            return {
+              token: null
+            }
           }
         }
 


### PR DESCRIPTION
Currently, with the most recent build of nexus, passing an invalid Bearer token in the authorization header causes jsonwebtoken to throw an error on verify(...), which is not caught properly by nexus and results in unhandledRejection which terminates the nexus application.

This PR adds a try/catch block around jsonwebtoken.verify to return a null token in the context if the token provided is invalid (same behaviour as if the Authorization header was invalid)